### PR TITLE
Add license to gemspec.

### DIFF
--- a/kamino.gemspec
+++ b/kamino.gemspec
@@ -4,6 +4,7 @@ Gem::Specification.new do |s|
   s.name        = "kamino"
   s.version     = Kamino::VERSION
   s.platform    = Gem::Platform::RUBY
+  s.license     = "MIT"
   s.authors     = ["Ho-Sheng Hsiao"]
   s.email       = ["hosh@opscode.com"]
   s.homepage    = "http://github.com/hosh/kamino"


### PR DESCRIPTION
It would be awesome if the license would be available through the RubyGems API. I'm working on [VersionEye](https://www.versioneye.com) and for us the license information is very important. 
